### PR TITLE
Add OS Unicode column

### DIFF
--- a/steamy
+++ b/steamy
@@ -1,4 +1,12 @@
 #!perl
+use utf8;
+use strict;
+use autodie;
+use warnings;
+use warnings    qw< FATAL  utf8     >;
+use open        qw< :std  :utf8     >;
+use charnames   qw< :full >;
+use feature     qw< unicode_strings >;
 use rjbs;
 
 # This program was written for http://jfdi.club/ game-playing club.
@@ -43,6 +51,8 @@ my $ua   = LWP::UserAgent->new;
 my $api_key = $opt->key;
 my @userslugs = @ARGV;
 
+binmode(STDOUT, ":encoding(UTF-8)");
+
 my %BLACKLISTED = (
   340    => '"Half-Life 2: Lost Cost" is a tech demo',
   223530 => '"Left 4 Dead 2 Beta" is a beta',
@@ -61,7 +71,7 @@ sub userslug_to_steamid {
 
   die "fail" unless $res->is_success;
 
-  open my $fh, '<', \$res->decoded_content(charset => 'none')
+  open my $fh, '<:raw', \$res->decoded_content(charset => 'none')
     or die "error making handle to XML results: $!";
 
   my $doc = XML::LibXML->load_xml(IO => $fh);
@@ -125,6 +135,25 @@ sub game_price ($appid) {
   return $price_data->{final} / 100;
 }
 
+sub game_os ($appid) {
+  my $uri = sprintf 'http://store.steampowered.com/api/appdetails?appids=%s',
+    $appid;
+
+  my $res = $ua->$cached_get($uri);
+  return unless $res->is_success;
+
+  my $data = $JSON->decode($res->decoded_content);
+
+  my $p = $data->{$appid}{data}{platforms};
+  my $ret = '';
+
+  $ret .= $p->{windows} ? " \N{DESKTOP WINDOW} " : '   ';
+  $ret .= $p->{mac}     ? " \N{GREEN APPLE} "    : '   ';
+  $ret .= $p->{linux}   ? " \N{PENGUIN} "        : '   ';
+
+  $ret
+}
+
 my @app_ids = sort { $GAME{$b}{unplayers} <=> $GAME{$a}{unplayers}
                   || $GAME{$b}{owners}    <=> $GAME{$a}{owners}
                   || $GAME{$a}{name} cmp $GAME{$b}{name} } keys %GAME;
@@ -140,11 +169,12 @@ for my $appid (@app_ids) {
 
   my $unowners = @userslugs - ($game->{owners} // 0);
 
-  printf " %2i | %2i |  %2i | \$%4.0f | %s (%s)\n",
+  printf " %2i | %2i |  %2i | \$%4.0f | % 9s | %s (%s)\n",
     $game->{unplayers} + $unowners, # everyone who has not played the game
     $unowners,                      # people who would have to buy the game
     $game->{players} // 0,          # owned it, played it
     game_price($appid) // -1,
+    game_os($appid) // '',
     $game->{name},
     $appid;
 }

--- a/steamy
+++ b/steamy
@@ -25,6 +25,9 @@ my ($opt, $usage) = describe_options(
   [ 'key=s',    'Steam API key',           { default => $ENV{STEAM_API_KEY} } ],
   [ 'limit=i',  'stop listing after this many items', { default => 25 }       ],
   [ 'cache-duration=s',  'Duration for new items in cache (default is "6 hours")', { default => '6 hours' }       ],
+  [ 'linux',   'Require linux support',                                       ],
+  [ 'mac',     'Require mac support',                                         ],
+  [ 'windows', 'Require windows support',                                     ],
 );
 
 $usage->die unless @ARGV;
@@ -148,6 +151,12 @@ sub game_os ($appid) {
   my $p = $data->{$appid}{data}{platforms};
   my $ret = '';
 
+  # I am a monster
+  no warnings;
+  next GAME if $opt->linux && !$p->{linux};
+  next GAME if $opt->mac && !$p->{mac};
+  next GAME if $opt->windows && !$p->{windows};
+
   $ret .= $p->{windows} ? " \N{DESKTOP WINDOW} " : '   ';
   $ret .= $p->{mac}     ? " \N{GREEN APPLE} "    : '   ';
   $ret .= $p->{linux}   ? " \N{PENGUIN} "        : '   ';
@@ -161,6 +170,7 @@ my @app_ids = sort { $GAME{$b}{unplayers} <=> $GAME{$a}{unplayers}
 
 $#app_ids = $opt->limit - 1 if $opt->limit and @app_ids > $opt->limit;
 
+GAME:
 for my $appid (@app_ids) {
   my $game = $GAME{$appid};
 

--- a/steamy
+++ b/steamy
@@ -17,6 +17,7 @@ use JSON;
 use LWP::UserAgent;
 use XML::LibXML;
 use CHI;
+use Encode;
 
 my ($opt, $usage) = describe_options(
   '%c %o USERID...',
@@ -175,7 +176,7 @@ for my $appid (@app_ids) {
     $game->{players} // 0,          # owned it, played it
     game_price($appid) // -1,
     game_os($appid) // '',
-    $game->{name},
+    decode('UTF-8', $game->{name}),
     $appid;
 }
 

--- a/steamy
+++ b/steamy
@@ -8,15 +8,34 @@ use HTML::TreeBuilder;
 use JSON;
 use LWP::UserAgent;
 use XML::LibXML;
+use CHI;
 
 my ($opt, $usage) = describe_options(
   '%c %o USERID...',
   [ 'time=i',   'playtime allowed before exclusion (min.)', { default => 10 } ],
   [ 'key=s',    'Steam API key',           { default => $ENV{STEAM_API_KEY} } ],
   [ 'limit=i',  'stop listing after this many items', { default => 25 }       ],
+  [ 'cache-duration=s',  'Duration for new items in cache (default is "6 hours")', { default => '6 hours' }       ],
 );
 
 $usage->die unless @ARGV;
+
+my $cache = CHI->new(
+  driver => 'File',
+  root_dir => "$ENV{HOME}/.steamy-cache"
+);
+
+my $cached_get = sub {
+  my ($ua, $uri) = @_;
+
+  if (my $ret = $cache->get($uri)) {
+    return $ret
+  } else {
+    my $response = $ua->get($uri);
+    $cache->set($uri, $response, $opt->cache_duration) if $response->is_success;
+    return $response
+  }
+};
 
 my $JSON = JSON->new;
 my $ua   = LWP::UserAgent->new;
@@ -38,7 +57,7 @@ sub userslug_to_steamid {
 
   my $uri = sprintf 'https://steamcommunity.com/id/%s/?xml=1', $userslug;
 
-  my $res = $ua->get($uri);
+  my $res = $ua->$cached_get($uri);
 
   die "fail" unless $res->is_success;
 
@@ -66,7 +85,7 @@ for my $userslug (@userslugs) {
     $api_key,
     $steamid;
 
-  my $json = $ua->get($owned_uri)->decoded_content;
+  my $json = $ua->$cached_get($owned_uri)->decoded_content;
 
   my $data = $JSON->decode($json);
 
@@ -95,7 +114,7 @@ sub game_price ($appid) {
   my $uri = sprintf 'http://store.steampowered.com/api/appdetails?appids=%s',
     $appid;
 
-  my $res = $ua->get($uri);
+  my $res = $ua->$cached_get($uri);
   return unless $res->is_success;
 
   my $data = $JSON->decode($res->decoded_content);


### PR DESCRIPTION
This works pretty well, but it uncovers some odd issue where some games get what
looks like mojibake to my untrained eyes.  For example I see this:

```
 13 | 13 |   1 | $  10 |  🗔  🍏  🐧  | STAR WARSâ¢ Knights of the Old Republicâ¢ II: The Sith Lordsâ¢ (208580)
```

I assume that the data we get from steam is already utf8 or something and maybe
needs to decoded from bytes or something.  If I can figure out how to fix that
I'll update the branch.  You can probably tell sooner though so pushing this
now.
